### PR TITLE
Removes unnecessary code from 05-omop542-vocab-setup

### DIFF
--- a/omop-cdm-v3/04-omop542-cdm-setup.sql
+++ b/omop-cdm-v3/04-omop542-cdm-setup.sql
@@ -1,12 +1,12 @@
 -- Databricks notebook source
 -- MAGIC %md
--- MAGIC Matt Cutini on 20250806: This notebook is a carry-over from the old accelerator notebook '2-omop531-cdm-setup' and I am starting to go through the cells and create streaming tables while also incorporating the code from the old notebook '4-omop531-etl-synthea'. In the end we should have one set of code that combines the old notebooks and creates STs and MVs in a Lakeflow Declarative Pipeline.
+-- MAGIC Matt Cutini on 20250806: This notebook is a carry-over from the old accelerator notebook '2-omop531-cdm-setup' and I am starting to go through the cells and create streaming tables while also incorporating the code from the old notebook '4-omop531-etl-synthea'. In the end we should have one set of code that combines the old notebooks and creates STs and MVs in a Lakeflow Declarative Pipeline. In the end we will probably not have this notebook at all, and will just have what's currently called notebook '05-omop542-vocab-setup' run and then have the Lakeflow Declarative Pipeline run. 
 
 -- COMMAND ----------
 
 -- DBTITLE 0,Drop Existing Database
-CREATE STREAMING TABLE person 
-AS
+-- CREATE STREAMING TABLE person 
+-- AS
 SELECT
   hash(ID) AS PERSON_ID
 , GENDER AS GENDER_CONCEPT_ID
@@ -15,7 +15,7 @@ SELECT
 , DAY(BIRTHDATE) AS DAY_OF_BIRTH
 , BIRTHDATE AS BIRTH_DATETIME
 , RACE.CONCEPT_ID AS RACE_CONCEPT_ID
-, ETHNICITY.CONCEPT_ID AS ETHNICITY_CONCEPT_ID
+-- , ETHNICITY.CONCEPT_ID AS ETHNICITY_CONCEPT_ID
 , NULL AS LOCATION_ID
 , NULL AS PROVIDER_ID
 , NULL AS CARE_SITE_ID
@@ -27,8 +27,8 @@ SELECT
 , ETHNICITY AS ETHNICITY_SOURCE_VALUE
 , NULL AS ETHNICITY_SOURCE_CONCEPT_ID
 FROM hls_omop.cdm_542.patients
-JOIN hls_omop.vocab_531.concept RACE ON UPPER(RACE.CONCEPT_NAME) = UPPER(patients.RACE) -- TO DO: replace this vocab_531 table with voca_542 when it is ready
-JOIN hls_omop.vocab_531.concept ETHNICITY ON UPPER(ETHNICITY.CONCEPT_NAME) = UPPER(patients.ETHNICITY) -- TO DO: in addition to the above TO DO, further specify the join criteria
+LEFT JOIN hls_omop.vocab_542.concept RACE ON UPPER(RACE.CONCEPT_NAME) = UPPER(patients.RACE) AND UPPER(RACE.DOMAIN_ID) = 'RACE' AND UPPER(RACE.concept_class_id) = 'RACE' AND UPPER(RACE.vocabulary_id) = 'RACE'
+-- LEFT JOIN hls_omop.vocab_542.concept ETHNICITY ON UPPER(ETHNICITY.CONCEPT_NAME) = UPPER(patients.ETHNICITY) AND UPPER(ETHNICITY.DOMAIN_ID) = 'ETHNICITY' AND UPPER(ETHNICITY.concept_class_id) = 'ETHNICITY' AND UPPER(ETHNICITY.vocabulary_id) = 'ETHNICITY'
 
 -- COMMAND ----------
 

--- a/omop-cdm-v3/05-omop542-vocab-setup.py
+++ b/omop-cdm-v3/05-omop542-vocab-setup.py
@@ -1,7 +1,7 @@
 # Databricks notebook source
 # MAGIC %md
 # MAGIC # OMOP Vocabulary Setup
-# MAGIC Construct vocabulary tables, based on tables downloaded from [Athena](https://athena.ohdsi.org/search-terms/start) website and available here on `s3://hls-eng-data-public/data/rwe/omop-vocabs/`
+# MAGIC Construct vocabulary tables, based on tables downloaded from [Athena](https://athena.ohdsi.org/search-terms/start) website and available here on `s3://hls-eng-data-public/data/rwe/omop-vocabs-v542/`
 # MAGIC If you like to download a different dataset, downoad the vocabularies from [Athena](https://athena.ohdsi.org/search-terms/start) and
 # MAGIC use [databricks dbfs api](https://docs.databricks.com/dev-tools/api/latest/dbfs.html#dbfs-api) utilities to upload downloaded vocabularies to `dbfs` under your `vocab_path`.
 # MAGIC
@@ -11,7 +11,7 @@
 
 dbutils.widgets.text(name = "catalog_name", defaultValue="hls_omop", label="Catalog Name")
 dbutils.widgets.text(name = "schema_name", defaultValue="vocab_542", label="Schema Name")
-# dbutils.widgets.text(name = "volume_name", defaultValue="omop_vocab", label="Volume Name")
+# # dbutils.widgets.text(name = "volume_name", defaultValue="omop_vocab", label="Volume Name")
 
 # COMMAND ----------
 
@@ -32,134 +32,19 @@ spark.sql(f'USE SCHEMA {schema_name}')
 
 # COMMAND ----------
 
-# MAGIC %sql
-# MAGIC CREATE
-# MAGIC OR REPLACE TABLE CONCEPT (
-# MAGIC   CONCEPT_ID LONG,
-# MAGIC   CONCEPT_NAME STRING,
-# MAGIC   DOMAIN_ID STRING,
-# MAGIC   VOCABULARY_ID STRING,
-# MAGIC   CONCEPT_CLASS_ID STRING,
-# MAGIC   STANDARD_CONCEPT STRING,
-# MAGIC   CONCEPT_CODE STRING,
-# MAGIC   VALID_START_DATE DATE,
-# MAGIC   VALID_END_DATE DATE,
-# MAGIC   INVALID_REASON STRING
-# MAGIC ) USING DELTA;
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC CREATE
-# MAGIC OR REPLACE TABLE CONCEPT_ANCESTOR (
-# MAGIC   ANCESTOR_CONCEPT_ID LONG,
-# MAGIC   DESCENDANT_CONCEPT_ID LONG,
-# MAGIC   MIN_LEVELS_OF_SEPARATION LONG,
-# MAGIC   MAX_LEVELS_OF_SEPARATION LONG
-# MAGIC ) USING DELTA;
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC CREATE
-# MAGIC OR REPLACE TABLE CONCEPT_CLASS (
-# MAGIC   CONCEPT_CLASS_ID STRING,
-# MAGIC   CONCEPT_CLASS_NAME STRING,
-# MAGIC   CONCEPT_CLASS_CONCEPT_ID LONG
-# MAGIC ) USING DELTA;
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC CREATE
-# MAGIC OR REPLACE TABLE CONCEPT_RELATIONSHIP (
-# MAGIC   CONCEPT_ID_1 LONG,
-# MAGIC   CONCEPT_ID_2 LONG,
-# MAGIC   RELATIONSHIP_ID STRING,
-# MAGIC   VALID_START_DATE DATE,
-# MAGIC   VALID_END_DATE DATE,
-# MAGIC   INVALID_REASON STRING
-# MAGIC ) USING DELTA;
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC CREATE
-# MAGIC OR REPLACE TABLE CONCEPT_SYNONYM (
-# MAGIC   CONCEPT_ID LONG,
-# MAGIC   CONCEPT_SYNONYM_NAME STRING,
-# MAGIC   LANGUAGE_CONCEPT_ID LONG
-# MAGIC ) USING DELTA;
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC CREATE
-# MAGIC OR REPLACE TABLE DOMAIN (
-# MAGIC   DOMAIN_ID STRING,
-# MAGIC   DOMAIN_NAME STRING,
-# MAGIC   DOMAIN_CONCEPT_ID LONG
-# MAGIC ) USING DELTA;
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC CREATE
-# MAGIC OR REPLACE TABLE DRUG_STRENGTH (
-# MAGIC   DRUG_CONCEPT_ID LONG,
-# MAGIC   INGREDIENT_CONCEPT_ID LONG,
-# MAGIC   AMOUNT_VALUE DOUBLE,
-# MAGIC   AMOUNT_UNIT_CONCEPT_ID LONG,
-# MAGIC   NUMERATOR_VALUE DOUBLE,
-# MAGIC   NUMERATOR_UNIT_CONCEPT_ID LONG,
-# MAGIC   DENOMINATOR_VALUE DOUBLE,
-# MAGIC   DENOMINATOR_UNIT_CONCEPT_ID LONG,
-# MAGIC   BOX_SIZE LONG,
-# MAGIC   VALID_START_DATE DATE,
-# MAGIC   VALID_END_DATE DATE,
-# MAGIC   INVALID_REASON STRING
-# MAGIC ) USING DELTA;
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC CREATE
-# MAGIC OR REPLACE TABLE RELATIONSHIP (
-# MAGIC   RELATIONSHIP_ID STRING,
-# MAGIC   RELATIONSHIP_NAME STRING,
-# MAGIC   IS_HIERARCHICAL STRING,
-# MAGIC   DEFINES_ANCESTRY STRING,
-# MAGIC   REVERSE_RELATIONSHIP_ID STRING,
-# MAGIC   RELATIONSHIP_CONCEPT_ID LONG
-# MAGIC ) USING DELTA;
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC CREATE
-# MAGIC OR REPLACE TABLE SOURCE_TO_CONCEPT_MAP (
-# MAGIC   SOURCE_CODE STRING,
-# MAGIC   SOURCE_CONCEPT_ID LONG,
-# MAGIC   SOURCE_VOCABULARY_ID STRING,
-# MAGIC   SOURCE_CODE_DESCRIPTION STRING,
-# MAGIC   TARGET_CONCEPT_ID LONG,
-# MAGIC   TARGET_VOCABULARY_ID STRING,
-# MAGIC   VALID_START_DATE DATE,
-# MAGIC   VALID_END_DATE DATE,
-# MAGIC   INVALID_REASON STRING
-# MAGIC ) USING DELTA;
-
-# COMMAND ----------
-
-# MAGIC %sql
-# MAGIC CREATE
-# MAGIC OR REPLACE TABLE VOCABULARY (
-# MAGIC   VOCABULARY_ID STRING,
-# MAGIC   VOCABULARY_NAME STRING,
-# MAGIC   VOCABULARY_REFERENCE STRING,
-# MAGIC   VOCABULARY_VERSION STRING,
-# MAGIC   VOCABULARY_CONCEPT_ID LONG
-# MAGIC ) USING DELTA;
+# %sql
+# CREATE
+# OR REPLACE TABLE SOURCE_TO_CONCEPT_MAP (
+#   SOURCE_CODE STRING,
+#   SOURCE_CONCEPT_ID LONG,
+#   SOURCE_VOCABULARY_ID STRING,
+#   SOURCE_CODE_DESCRIPTION STRING,
+#   TARGET_CONCEPT_ID LONG,
+#   TARGET_VOCABULARY_ID STRING,
+#   VALID_START_DATE DATE,
+#   VALID_END_DATE DATE,
+#   INVALID_REASON STRING
+# ) USING DELTA;
 
 # COMMAND ----------
 
@@ -182,40 +67,31 @@ display(dbutils.fs.ls(vocab_s3_path))
 
 # COMMAND ----------
 
-# TO DO: run this code with the vocabularies for V5.4 
+from pyspark.sql.functions import to_date, col
 
-from pyspark.sql.functions import to_date
 spark.sql("set spark.sql.legacy.timeParserPolicy=LEGACY")
 spark.sql("set spark.sql.legacy.parquet.datetimeRebaseModeInWrite=LEGACY")
 
 tablelist = ["CONCEPT","VOCABULARY","CONCEPT_ANCESTOR","CONCEPT_RELATIONSHIP","RELATIONSHIP","CONCEPT_SYNONYM","DOMAIN","CONCEPT_CLASS","DRUG_STRENGTH"]
 for table in tablelist:
-  df = spark.read.csv(f'{vocab_s3_path}/{table}.csv', inferSchema=True, header=True, dateFormat="yyyy-MM-dd")
-  if table in ["CONCEPT","CONCEPT_RELATIONSHIP","DRUG_STRENGTH"] :
-    if 'valid_start_date' in df.columns and 'valid_end_date' in df.columns:    df = df.withColumn('valid_start_date', to_date(df.valid_start_date,'yyyy-MM-dd')).withColumn('valid_end_date', to_date(df.valid_end_date,'yyyy-MM-dd'))
-
+    df = spark.read.csv(
+        f'{vocab_s3_path}/{table}.csv',
+        inferSchema=True,
+        header=True,
+        dateFormat="yyyymmdd",
+        sep="\t"
+    )
     
-  df.write.format('delta').mode('overwrite').option('overwriteSchema','true').saveAsTable(f"{catalog_name}.{schema_name}.{table}")
-
-# COMMAND ----------
-
-# DBTITLE 1,display tables and counts of records
-tablecount = "SELECT '-' AS table, 0 as recs"
-for table in tablelist:
-  tablecount += " UNION SELECT '"+table+"', COUNT(1) FROM "+omop_version+"."+table
-tablecount += " ORDER BY 2 DESC"
-
-display(spark.sql(tablecount))
+    if table in ["CONCEPT", "CONCEPT_RELATIONSHIP", "DRUG_STRENGTH"]:
+        if 'valid_start_date' in df.columns and 'valid_end_date' in df.columns:
+            df = df.withColumn('valid_start_date', to_date(df.valid_start_date, 'yyyymmdd')).withColumn('valid_end_date', to_date(df.valid_end_date, 'yyyymmdd'))
+    
+    df.write.format('delta').mode('overwrite').option('overwriteSchema', 'true').saveAsTable(f"{catalog_name}.{schema_name}.{table}")
 
 # COMMAND ----------
 
 # MAGIC %md
 # MAGIC ## Create vocab map tables
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC #### source_to_standard_vocab_map
 
 # COMMAND ----------
 
@@ -266,7 +142,7 @@ display(spark.sql(tablecount))
 # MAGIC     c2.INVALID_REASON AS TARGET_INVALID_REASON,
 # MAGIC     c2.standard_concept AS TARGET_STANDARD_CONCEPT
 # MAGIC   FROM
-# MAGIC     source_to_concept_map stcm
+# MAGIC     source_to_concept_map stcm -- TO DO: Find out how the source_to_concept_map table is populated with data
 # MAGIC     LEFT OUTER JOIN CONCEPT c1 ON c1.concept_id = stcm.source_concept_id
 # MAGIC     LEFT OUTER JOIN CONCEPT c2 ON c2.CONCEPT_ID = stcm.target_concept_id
 # MAGIC   WHERE
@@ -275,15 +151,7 @@ display(spark.sql(tablecount))
 # MAGIC SELECT
 # MAGIC   *
 # MAGIC FROM
-# MAGIC   CTE_VOCAB_MAP
-# MAGIC   ;
-# MAGIC SELECT * FROM source_to_standard_vocab_map LIMIT 100
-# MAGIC ;
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC #### source_to_source_vocab_map
+# MAGIC   CTE_VOCAB_MAP;
 
 # COMMAND ----------
 
@@ -329,7 +197,7 @@ display(spark.sql(tablecount))
 # MAGIC     c2.INVALID_REASON AS TARGET_INVALID_REASON,
 # MAGIC     c2.standard_concept AS TARGET_STANDARD_CONCEPT
 # MAGIC   FROM
-# MAGIC     source_to_concept_map stcm
+# MAGIC     source_to_concept_map stcm -- TO DO: Find out how the source_to_concept_map table is populated with data
 # MAGIC     LEFT OUTER JOIN CONCEPT c1 ON c1.concept_id = stcm.source_concept_id
 # MAGIC     LEFT OUTER JOIN CONCEPT c2 ON c2.CONCEPT_ID = stcm.target_concept_id
 # MAGIC   WHERE
@@ -338,24 +206,5 @@ display(spark.sql(tablecount))
 # MAGIC SELECT
 # MAGIC   *
 # MAGIC FROM
-# MAGIC   CTE_VOCAB_MAP
-# MAGIC ;
-# MAGIC SELECT * FROM source_to_source_vocab_map LIMIT 100
-# MAGIC ;
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC Copyright / License info of the notebook. Copyright Databricks, Inc. [2021].  The source in this notebook is provided subject to the [Databricks License](https://databricks.com/db-license-source).  All included or referenced third party libraries are subject to the licenses set forth below.
+# MAGIC   CTE_VOCAB_MAP;
 # MAGIC
-# MAGIC |Library Name|Library License|Library License URL|Library Source URL| 
-# MAGIC | :-: | :-:| :-: | :-:|
-# MAGIC |Synthea|Apache License 2.0|https://github.com/synthetichealth/synthea/blob/master/LICENSE| https://github.com/synthetichealth/synthea|
-# MAGIC | OHDSI/CommonDataModel| Apache License 2.0 | https://github.com/OHDSI/CommonDataModel/blob/master/LICENSE | https://github.com/OHDSI/CommonDataModel |
-# MAGIC | OHDSI/ETL-Synthea| Apache License 2.0 | https://github.com/OHDSI/ETL-Synthea/blob/master/LICENSE | https://github.com/OHDSI/ETL-Synthea |
-# MAGIC |OHDSI/OMOP-Queries|||https://github.com/OHDSI/OMOP-Queries|
-# MAGIC |The Book of OHDSI | Creative Commons Zero v1.0 Universal license.|https://ohdsi.github.io/TheBookOfOhdsi/index.html#license|https://ohdsi.github.io/TheBookOfOhdsi/|
-
-# COMMAND ----------
-
-

--- a/omop-cdm-v3/06-omop542-etl-synthea.sql
+++ b/omop-cdm-v3/06-omop542-etl-synthea.sql
@@ -1,6 +1,6 @@
 -- Databricks notebook source
 -- MAGIC %md
--- MAGIC # 20250730 MC: I'm commenting out all of the code up until Cell 35. I just want to create the condition occurrence table today so that I can start testing the next notebook. All cells other than Cell 35 will need to be worked on.
+-- MAGIC Matt Cutini on 20250811: The code that's in this notebook should be combined with the code that's in notebook '04-omop542-cdm-setup' and the combined result should be turned into a Lakeflow Declarative Pipeline. 
 
 -- COMMAND ----------
 


### PR DESCRIPTION
There were create table statements in the notebook 05-omop542-vocab-setup that are not necessary, considering that we are creating the vocabulary tables based on the CSV files downloaded from the S3 bucket hls-eng-data-public/data/rwe/omop-vocabs-v542/

There are a couple of TO DOs to further clean up this notebook, such as getting the right code to populate the source_to_concept_map table. 